### PR TITLE
Add Odoo test image workflows

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,14 @@
+name: Build Docker image
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - name: Build image
+        run: docker build -t gh-selfhosted-runner:latest .

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,7 +2,7 @@ name: Build Docker image
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "17.0" ]
 
 jobs:
   build:
@@ -11,4 +11,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
       - name: Build image
-        run: docker build -t gh-selfhosted-runner:latest .
+        run: docker build -t odoo-runner:17.0 .

--- a/.github/workflows/odoo-test-example.yml
+++ b/.github/workflows/odoo-test-example.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:15
+        image: postgres:latest
         env:
           POSTGRES_USER: odoo
           POSTGRES_PASSWORD: odoo
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
       - name: Build test image
-        run: docker build -t gh-selfhosted-runner:latest .
+        run: docker build -t odoo-runner:17.0 .
       - name: Clone addon repository
         run: git clone https://example.com/your/repo.git /tmp/extra-addons
       - name: Run Odoo tests
@@ -29,5 +29,5 @@ jobs:
           docker run --network host \
             --entrypoint odoo \
             -v /tmp/extra-addons:/mnt/extra-addons \
-            gh-selfhosted-runner:latest \
+            odoo-runner:17.0 \
             -i base --db_host=localhost --db_user=odoo --db_password=odoo --stop-after-init --test-enable

--- a/.github/workflows/odoo-test-example.yml
+++ b/.github/workflows/odoo-test-example.yml
@@ -1,0 +1,33 @@
+name: Example Odoo tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: odoo
+          POSTGRES_PASSWORD: odoo
+          POSTGRES_DB: odoo
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U odoo" --health-interval=10s --health-timeout=5s --health-retries=5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - name: Build test image
+        run: docker build -t gh-selfhosted-runner:latest .
+      - name: Clone addon repository
+        run: git clone https://example.com/your/repo.git /tmp/extra-addons
+      - name: Run Odoo tests
+        run: |
+          docker run --network host \
+            --entrypoint odoo \
+            -v /tmp/extra-addons:/mnt/extra-addons \
+            gh-selfhosted-runner:latest \
+            -i base --db_host=localhost --db_user=odoo --db_password=odoo --stop-after-init --test-enable

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,9 @@ RUN chown -R runner:runner /home/runner
 COPY entrypoint.sh /home/runner/actions-runner/entrypoint.sh
 RUN chmod +x /home/runner/actions-runner/entrypoint.sh
 
+# Crear carpeta de trabajo final donde se clonarán los módulos
+RUN mkdir -p /mnt/extra-addons && chown -R runner:runner /mnt/extra-addons
+WORKDIR /mnt/extra-addons
+
 USER runner
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["/home/runner/actions-runner/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,20 @@ A self-contained Docker image that runs a GitHub Actions self-hosted runner insi
 
 ## 🏗️ Build the Image
 
-Clone this repo (or place the files in a folder), then:
+Clone this repo (or place the files in a folder) and build the Docker image:
 
 ```bash
 docker build -t gh-selfhosted-runner:latest .
+```
+
+The image uses `/mnt/extra-addons` as working directory so your Odoo modules
+can be cloned there.
+
+This repository also provides a GitHub Actions workflow (`build-image.yml`) that
+automatically builds the image on each push.
+
+## 🧪 Example Workflow
+
+The `odoo-test-example.yml` workflow shows how to spin up a PostgreSQL service,
+clone your modules into `/mnt/extra-addons` and run Odoo's test suite inside the
+container.


### PR DESCRIPTION
## Summary
- set final workdir to `/mnt/extra-addons`
- document new workdir and workflows
- create build workflow for the Docker image
- add example workflow that installs PostgreSQL and runs Odoo tests

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68438a328560832aac200c3447e4f175